### PR TITLE
Use IranianSerifWeb font only for Arabic script unicode ranges

### DIFF
--- a/resources/sass/fonts-fa.scss
+++ b/resources/sass/fonts-fa.scss
@@ -3,4 +3,5 @@
 	src:  url('../fonts/IranianSerifWeb-Regular.woff') format('woff');
 	font-weight: bold;
 	font-style: normal;
+	unicode-range: U+0600-06FF, U+200C-200E, U+2010-2011, U+FB50-FDFF, U+FE80-FEFC;
 }


### PR DESCRIPTION
This allows Bootstrap default fonts to be applied to Latin text.