### PR TITLE
Use IranianSerifWeb font only for Arabic script unicode ranges

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <link rel="icon" href="../../favicon.ico">
     <title>RTL theme for bootstrap 4</title>
     <!-- Bootstrap core CSS -->
-    <link href="public/css/style-rtl.alpha6.min.css" rel="stylesheet">
+    <link href="public/css/style-rtl.beta.min.css" rel="stylesheet">
 </head>
 
 <body>

--- a/resources/sass/fonts-fa.scss
+++ b/resources/sass/fonts-fa.scss
@@ -3,4 +3,5 @@
 	src:  url('../fonts/IranianSerifWeb-Regular.woff') format('woff');
 	font-weight: bold;
 	font-style: normal;
+	unicode-range: U+0600-06FF, U+200C-200E, U+2010-2011, U+FB50-FDFF, U+FE80-FEFC;
 }

--- a/resources/sass/typography.scss
+++ b/resources/sass/typography.scss
@@ -3,5 +3,5 @@
   Lenus.org
 */
 body{
-    font-family: 'IranianSerifWeb-Regular' !important;
+    font-family: 'IranianSerifWeb-Regular' $font-family-base !important;
 }


### PR DESCRIPTION
This allows Bootstrap default fonts to be applied to Latin text.